### PR TITLE
build: remove pre-commit hooks as they interrupt the flow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,0 @@
-pnpm lint-staged
-pnpm nx affected:lint
-pnpm nx affected:test


### PR DESCRIPTION
they tend to discourage frequent commits
they interrupt us while we are thinking of the next step (hence the commit)
we have the CI for that
