### PR TITLE
test(angular): prevent vite from bundle root injector singleton twice

### DIFF
--- a/tests/angular-wide/project.json
+++ b/tests/angular-wide/project.json
@@ -65,7 +65,10 @@
           "buildTarget": "angular-wide:build:development"
         },
         "testronaut": {
-          "buildTarget": "angular-wide:build:testronaut"
+          "buildTarget": "angular-wide:build:testronaut",
+          "prebundle": {
+            "exclude": ["@testronaut/angular"]
+          }
         }
       },
       "defaultConfiguration": "development"

--- a/tests/angular-wide/testronaut/main.ts
+++ b/tests/angular-wide/testronaut/main.ts
@@ -1,4 +1,3 @@
-import '@angular/core';
 import './generated';
 import { setUpTestronautAngular } from '@testronaut/angular/browser';
 


### PR DESCRIPTION
vite prebundling duplicates the root injector
singleton in distinct bundles causing https://angular.dev/errors/NG0203 error
