### PR TITLE
build(angular,core): fix commonjs support

### DIFF
--- a/packages/angular/browser.d.ts
+++ b/packages/angular/browser.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/browser.esm';
+export * from './dist/browser';

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@testronaut/angular",
-  "type": "module",
   "version": "0.0.2",
   "sideEffects": false,
   "files": [
@@ -15,22 +14,22 @@
     "@testronaut/core": "workspace:*",
     "typescript": "~5.6.0"
   },
-  "module": "./dist/index.esm.js",
-  "main": "./dist/index.cjs.js",
-  "types": "./dist/index.esm.d.ts",
+  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.esm.d.ts",
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     },
     "./browser": {
-      "types": "./dist/browser.esm.d.ts",
-      "require": "./dist/browser.cjs.js",
-      "import": "./dist/browser.esm.js",
-      "default": "./dist/browser.esm.js"
+      "types": "./dist/browser.d.ts",
+      "require": "./dist/browser.cjs",
+      "import": "./dist/browser.mjs",
+      "default": "./dist/browser.mjs"
     }
   }
 }

--- a/packages/angular/rollup.config.cjs
+++ b/packages/angular/rollup.config.cjs
@@ -1,11 +1,8 @@
-const { withNx } = require('@nx/rollup/with-nx');
+const {
+  createRollupConfig,
+} = require('../build-utils/create-rollup-config.cjs');
 
-module.exports = withNx({
+module.exports = createRollupConfig({
   main: './src/index.ts',
   additionalEntryPoints: ['./src/browser.ts'],
-  generatePackageJson: false,
-  outputPath: './dist',
-  tsConfig: './tsconfig.lib.json',
-  compiler: 'tsc',
-  format: ['cjs', 'esm'],
 });

--- a/packages/build-utils/create-rollup-config.cjs
+++ b/packages/build-utils/create-rollup-config.cjs
@@ -1,0 +1,30 @@
+const { withNx } = require('@nx/rollup/with-nx');
+
+/**
+ * @param {string} main
+ * @param {string[]} additionalEntryPoints
+ */
+exports.createRollupConfig = ({ main, additionalEntryPoints }) => {
+  const base = withNx({
+    main,
+    additionalEntryPoints,
+    generatePackageJson: false,
+    outputPath: './dist',
+    tsConfig: './tsconfig.lib.json',
+    compiler: 'tsc',
+    format: ['cjs', 'esm'],
+  });
+
+  return {
+    ...base,
+    output: base.output.map((output) => {
+      const fileNames = output.format === 'cjs' ? '[name].cjs' : '[name].mjs';
+
+      return {
+        ...output,
+        chunkFileNames: fileNames,
+        entryFileNames: fileNames,
+      };
+    }),
+  };
+};

--- a/packages/core/devkit.d.ts
+++ b/packages/core/devkit.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/devkit.esm';
+export * from './dist/devkit';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@testronaut/core",
-  "type": "module",
   "version": "0.0.2",
   "sideEffects": false,
   "files": [
@@ -13,22 +12,22 @@
     "@playwright/test": "^1.36.0",
     "typescript": "~5.6.2"
   },
-  "module": "./dist/index.esm.js",
-  "main": "./dist/index.cjs.js",
-  "types": "./dist/index.esm.d.ts",
+  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.esm.d.ts",
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     },
     "./devkit": {
-      "types": "./dist/devkit.esm.d.ts",
-      "require": "./dist/devkit.cjs.js",
-      "import": "./dist/devkit.esm.js",
-      "default": "./dist/devkit.esm.js"
+      "types": "./dist/devkit.d.ts",
+      "require": "./dist/devkit.cjs",
+      "import": "./dist/devkit.mjs",
+      "default": "./dist/devkit.mjs"
     }
   }
 }

--- a/packages/core/rollup.config.cjs
+++ b/packages/core/rollup.config.cjs
@@ -1,11 +1,8 @@
-const { withNx } = require('@nx/rollup/with-nx');
+const {
+  createRollupConfig,
+} = require('../build-utils/create-rollup-config.cjs');
 
-module.exports = withNx({
+module.exports = createRollupConfig({
   main: './src/index.ts',
   additionalEntryPoints: ['./src/devkit.ts'],
-  generatePackageJson: false,
-  outputPath: './dist',
-  tsConfig: './tsconfig.lib.json',
-  compiler: 'tsc',
-  format: ['cjs', 'esm'],
 });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,
-    "types": ["node"]
+    "types": ["node"],
+    "module": "ES2022",
+    "moduleResolution": "bundler"
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
by removing `type: module` from package.json and renaming files
to `.cjs` and `.mjs` instead of `.cjs.js` and `.esm.js`.

As mentioned here https://github.com/testronaut/testronaut/pull/37#issuecomment-3275433017,
removing `type` from package.json was causing `module has to be ESM to be used in playwright
with ESM` error within the workspace.

Using `type: module` turned out to cause issues with commonjs workspaces (for some reason,
within the workspace, it works).

For some reason, NodeJS would consider our package ESM but still use the `.cjs.js` entrypoint,
probably because `package.json#main` is `index.cjs.js` while the type is module.

This would cause "require not found" error.
