### PR TITLE
docs/move docs to base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.0.3 (2025-09-17)
+
+### 🩹 Fixes
+
+- **angular,core:** fix commonjs support ([#56](https://github.com/testronaut/testronaut/pull/56))
+- **core:** make playwright a peer dependency ([#55](https://github.com/testronaut/testronaut/pull/55))
+
+### ❤️ Thank You
+
+- Younes Jaaidi @yjaaidi
+
 ## 0.0.2 (2025-09-11)
 
 ### 🩹 Fixes

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
   url: 'https://testronaut.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/testronaut/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testronaut/angular",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "sideEffects": false,
   "files": [
     "*.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testronaut/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "sideEffects": false,
   "files": [
     "*.d.ts",


### PR DESCRIPTION
- **chore(release): publish 0.0.3**
- **docs: move docs URL to base instead of `/testronaut` path**
