### PR TITLE
fix(angular,core): remove commonjs bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
-
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: pnpm dlx nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
+          version: 10
 
       # Cache node_modules
       - uses: actions/setup-node@v4
@@ -38,6 +32,32 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps
       - uses: nrwl/nx-set-shas@v4
-      - run: pnpm exec nx affected -t lint test build e2e typecheck --exclude=tag:type:demo
+      - run: pnpm exec nx affected -t build e2e lint test testronaut typecheck --exclude=tag:type:demo
+      - run: pnpm nx-cloud fix-ci
+        if: always()
+
+  test-commonjs:
+    name: Test CommonJS Support
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
+      - uses: nrwl/nx-set-shas@v4
+      # This target changes the `package.json` and `pnpm-lock.yaml` files.
+      # Do not run anything that might be affected by this after this step.
+      - run: pnpm exec nx affected -t testronaut --configuration commonjs --exclude=tag:type:demo
       - run: pnpm nx-cloud fix-ci
         if: always()

--- a/nx.json
+++ b/nx.json
@@ -53,7 +53,8 @@
     },
     "@nx/vite:test": {
       "cache": true,
-      "inputs": ["default", "^production"]
+      "inputs": ["default", "^production"],
+      "dependsOn": ["^build"]
     }
   },
   "plugins": [

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@testronaut/angular",
   "version": "0.0.3",
+  "type": "module",
   "sideEffects": false,
   "files": [
     "*.d.ts",
@@ -15,20 +16,15 @@
     "typescript": "~5.6.0"
   },
   "module": "./dist/index.mjs",
-  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
     "./browser": {
       "types": "./dist/browser.d.ts",
-      "require": "./dist/browser.cjs",
-      "import": "./dist/browser.mjs",
       "default": "./dist/browser.mjs"
     }
   }

--- a/packages/build-utils/create-rollup-config.cjs
+++ b/packages/build-utils/create-rollup-config.cjs
@@ -12,19 +12,15 @@ exports.createRollupConfig = ({ main, additionalEntryPoints }) => {
     outputPath: './dist',
     tsConfig: './tsconfig.lib.json',
     compiler: 'tsc',
-    format: ['cjs', 'esm'],
+    format: ['esm'],
   });
 
   return {
     ...base,
-    output: base.output.map((output) => {
-      const fileNames = output.format === 'cjs' ? '[name].cjs' : '[name].mjs';
-
-      return {
-        ...output,
-        chunkFileNames: fileNames,
-        entryFileNames: fileNames,
-      };
-    }),
+    output: base.output.map((output) => ({
+      ...output,
+      chunkFileNames: '[name].mjs',
+      entryFileNames: '[name].mjs',
+    })),
   };
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@testronaut/core",
   "version": "0.0.3",
+  "type": "module",
   "sideEffects": false,
   "files": [
     "*.d.ts",
@@ -15,20 +16,15 @@
     "@playwright/test": "^1.36.0"
   },
   "module": "./dist/index.mjs",
-  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
     "./devkit": {
       "types": "./dist/devkit.d.ts",
-      "require": "./dist/devkit.cjs",
-      "import": "./dist/devkit.mjs",
       "default": "./dist/devkit.mjs"
     }
   }

--- a/tests/angular-wide/project.json
+++ b/tests/angular-wide/project.json
@@ -66,9 +66,8 @@
         },
         "testronaut": {
           "buildTarget": "angular-wide:build:testronaut",
-          "prebundle": {
-            "exclude": ["@testronaut/angular"]
-          }
+          "liveReload": false,
+          "prebundle": false
         }
       },
       "defaultConfiguration": "development"
@@ -100,7 +99,7 @@
         ]
       }
     },
-    "e2e": {
+    "testronaut": {
       /* Using custom command instead of plugin due to chicken and egg situation
        * where plugin loads playwright config which needs a built version of our packages
        * and we need to load the nx graph to be able to build the packages. */
@@ -108,12 +107,16 @@
       "options": {
         "commands": [
           "playwright test",
-          "playwright test --config=playwright.failing-multi-worker.config.ts",
-          /* Test commonjs support. */
-          "playwright test --config=playwright.config.cts"
+          "playwright test --config=playwright.failing-multi-worker.config.ts"
         ],
         "cwd": "{projectRoot}",
         "parallel": false
+      },
+      "configurations": {
+        "commonjs": {
+          "commands": ["{projectRoot}/test-commonjs-support.sh"],
+          "cwd": "{workspaceRoot}"
+        }
       }
     }
   }

--- a/tests/angular-wide/test-commonjs-support.sh
+++ b/tests/angular-wide/test-commonjs-support.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+set -e
+set -x
+
+# set global git user if not already set
+if [ -z "$(git config --global user.email)" ] && [ -z "$(git config --global user.name)" ]; then
+  git config --global user.email "testrobot@testronaut.dev"
+  git config --global user.name "Testrobot"
+fi
+
+nx local-registry &
+
+REGISTRY_PID=$!
+
+nx release patch -y
+
+pnpm add -Dw "@testronaut/angular@latest" "@testronaut/core@latest"
+
+kill $REGISTRY_PID
+
+pnpm playwright test --config=tests/angular-wide/playwright.config.cts --reporter=list


### PR DESCRIPTION
Node.js 22.12.0 and higher support `require(esm)`.

We thought that Playwright was always transforming the esm files thus causing `exports` error when transforming `import.meta.url` but this seems to only happen in our workspace because the packages in `node_modules` are aliases that resolve to `packages/*/dist` so Playwright sees them as source code to transform. 