### PR TITLE
docs: :memo: align test name with example

### DIFF
--- a/docs/docs/03-getting-started.md
+++ b/docs/docs/03-getting-started.md
@@ -8,7 +8,7 @@ Better code than words, here is a simple example of an Angular Testronaut test:
 import { test, expect } from '@testronaut/angular';
 import { Basket } from './basket.ng';
 
-test('should be able to login', async ({ page, mount }) => {
+test('should render clear basket button', async ({ page, mount }) => {
   await mount(Basket);
   await expect(page.getByRole('button', { name: 'Clear basket' })).toBeVisible();
 });


### PR DESCRIPTION
Updates the test title name to match the test in the Getting Started / Quick glance section in the docs.

Before:
<img width="751" height="161" alt="title-before" src="https://github.com/user-attachments/assets/77dc1679-58b4-4bc7-bdd9-6005f36732d7" />

After:
<img width="751" height="161" alt="title-after" src="https://github.com/user-attachments/assets/f571c43b-482e-4207-9971-bb5d30289dc2" />


Fixes #85