### PR TITLE
refactor: rename `runInBrowser` to `inPage` 1/2

### DIFF
--- a/demos/angular/src/testronaut-examples/2-sub-components.pw.ts
+++ b/demos/angular/src/testronaut-examples/2-sub-components.pw.ts
@@ -13,13 +13,13 @@ import { ShallowClickDirective } from './test-helpers/shallow-click.directive';
  * `ClickDirective` (selector `button[appClick]`) via `TestBed.overrideComponent`.
  *
  * Any code, which runs in the browser, has to be imported from a separate or has
- * be declared within the `runInBrowser` function.
+ * be declared within the `inPage` function.
  *
  * This test shows both ways for shallowing the `MessageComponent` and the `ClickDirective`, via
  * `ShallowMessageComponent` and `ShallowClickDirective`.
  *
- * A unique `runInBrowser` identifier is provided because this file performs multiple browser actions
- * (e.g. `mount` and `runInBrowser`).
+ * A unique `inPage` identifier is provided because this file performs multiple browser actions
+ * (e.g. `mount` and `inPage`).
  */
 test('no test doubles', async ({ mount, page }) => {
   await mount('mount1', ClickMeWithSub);
@@ -34,8 +34,8 @@ test('no test doubles', async ({ mount, page }) => {
   await expect(buttonLocator).toBeDisabled();
 });
 
-test('embedded shallow components', async ({ mount, page, runInBrowser }) => {
-  await runInBrowser('override with embedded shallows', () => {
+test('embedded shallow components', async ({ mount, page, inPage }) => {
+  await inPage('override with embedded shallows', () => {
     @Component({
       selector: 'app-message',
       template: `<p data-testid="shallowed-message">Shallowed</p>`,
@@ -70,9 +70,9 @@ test('embedded shallow components', async ({ mount, page, runInBrowser }) => {
 test('externalized shallow components', async ({
   mount,
   page,
-  runInBrowser,
+  inPage,
 }) => {
-  await runInBrowser('override with externalized shallows', () => {
+  await inPage('override with externalized shallows', () => {
     TestBed.overrideComponent(ClickMeWithSub, {
       set: {
         imports: [ShallowMessageComponent, ShallowClickDirective],

--- a/demos/angular/src/testronaut-examples/3-services.pw.ts
+++ b/demos/angular/src/testronaut-examples/3-services.pw.ts
@@ -17,10 +17,10 @@ import {
  * The test suite overrides both the `MessageService` via `TestBed.configureTestingModule`.
  *
  * Any code, which runs in the browser, has to be imported from a separate or has
- * be declared within the `runInBrowser` function.
+ * be declared within the `inPage` function.
  *
- * A unique `runInBrowser` identifier is provided because this file performs multiple browser actions
- * (e.g. `mount` and `runInBrowser`).
+ * A unique `inPage` identifier is provided because this file performs multiple browser actions
+ * (e.g. `mount` and `inPage`).
  */
 test('should use the real message service', async ({ mount, page }) => {
   await mount('mount1', ClickMe);
@@ -32,9 +32,9 @@ test.describe('mocks', () => {
   test('should mock the message service embedded', async ({
     mount,
     page,
-    runInBrowser,
+    inPage,
   }) => {
-    await runInBrowser('mock the message service', () => {
+    await inPage('mock the message service', () => {
       class EmbeddedMockedMessageService {
         getMessage() {
           return 'Mocked Lift Off!';
@@ -59,9 +59,9 @@ test.describe('mocks', () => {
   test('should mock the message service (externalized)', async ({
     mount,
     page,
-    runInBrowser,
+    inPage,
   }) => {
-    await runInBrowser('mock the message service externalized', () => {
+    await inPage('mock the message service externalized', () => {
       TestBed.configureTestingModule({
         providers: [
           { provide: MessageService, useClass: MockedMessageService },
@@ -78,9 +78,9 @@ test.describe('fakes', () => {
   test('should fake the message service embedded', async ({
     mount,
     page,
-    runInBrowser,
+    inPage,
   }) => {
-    await runInBrowser('fake the message service embedded', () => {
+    await inPage('fake the message service embedded', () => {
       @Injectable({ providedIn: 'root' })
       class MessageServiceFake implements MessageService {
         #message = '';
@@ -112,9 +112,9 @@ test.describe('fakes', () => {
   test('should fake the message service externalized', async ({
     mount,
     page,
-    runInBrowser,
+    inPage,
   }) => {
-    await runInBrowser('fake the message service externalized', () => {
+    await inPage('fake the message service externalized', () => {
       TestBed.configureTestingModule({
         providers: [provideMessageServiceFake()],
       });

--- a/demos/angular/src/testronaut-examples/5-http-communication.pw.ts
+++ b/demos/angular/src/testronaut-examples/5-http-communication.pw.ts
@@ -16,15 +16,15 @@ for (const name of [
   test.describe(name, () => {
     test('respond via `HttpTestingController', async ({
       page,
-      runInBrowser,
+      inPage,
     }) => {
-      await runInBrowser('config1', () => {
+      await inPage('config1', () => {
         TestBed.configureTestingModule({
           providers: [provideHttpClient(), provideHttpClientTesting()],
         });
       });
 
-      await runInBrowser('mount1', { name }, ({ name }) => {
+      await inPage('mount1', { name }, ({ name }) => {
         TestBed.createComponent(
           (name.endsWith('httpResource')
             ? ClickMeWithResource
@@ -33,7 +33,7 @@ for (const name of [
       });
       await page.getByRole('button', { name: 'Click me' }).click();
 
-      await runInBrowser('respond1', () => {
+      await inPage('respond1', () => {
         const httpTestingController = TestBed.inject(HttpTestingController);
         httpTestingController
           .expectOne('https://testronaut.dev/lift-off')
@@ -42,14 +42,14 @@ for (const name of [
       await expect(page.getByText('Lift Off!')).toBeVisible();
     });
 
-    test('respond via page.route', async ({ page, runInBrowser }) => {
-      await runInBrowser('config2', () => {
+    test('respond via page.route', async ({ page, inPage }) => {
+      await inPage('config2', () => {
         TestBed.configureTestingModule({
           providers: [provideHttpClient()],
         });
       });
 
-      await runInBrowser('mount2', { name }, ({ name }) => {
+      await inPage('mount2', { name }, ({ name }) => {
         TestBed.createComponent(
           (name.endsWith('httpResource')
             ? ClickMeWithResource

--- a/demos/angular/src/testronaut-examples/6-routing.pw.ts
+++ b/demos/angular/src/testronaut-examples/6-routing.pw.ts
@@ -5,8 +5,8 @@ import { RouterTestingHarness } from '@angular/router/testing';
 import { expect, test } from '@testronaut/angular';
 import { RoutingMessage } from './components/6-click-me-with-routing';
 
-test('routing', async ({ mount, page, runInBrowser }) => {
-  await runInBrowser('mount', async () => {
+test('routing', async ({ mount, page, inPage }) => {
+  await inPage('mount', async () => {
     TestBed.configureTestingModule({
       providers: [
         provideRouter(

--- a/packages/angular/src/lib/playwright/angular-transform.spec.ts
+++ b/packages/angular/src/lib/playwright/angular-transform.spec.ts
@@ -8,7 +8,7 @@ import { describe } from 'vitest';
 import { angularTransform } from './angular-transform';
 
 describe(angularTransform.name, () => {
-  it('replaces anonymous mount call with runInBrowser + mount', () => {
+  it('replaces anonymous mount call with inPage + mount', () => {
     const result = transform(`
 import { test } from '@testronaut/angular';
 import { Hello } from './hello.component';
@@ -21,13 +21,13 @@ test('hello', async ({ mount }) => {
     expect(result.content).toContain(`\
 import { test } from '@testronaut/angular';
 import { Hello } from './hello.component';
-test('hello', async ({ runInBrowser }) => {
-    await runInBrowser(() => mount(Hello));
+test('hello', async ({ inPage }) => {
+    await inPage(() => mount(Hello));
 });
 `);
   });
 
-  it('replaces mount call with runInBrowser + mount', () => {
+  it('replaces mount call with inPage + mount', () => {
     const result = transform(`
 import { test } from '@testronaut/angular';
 import { Hello } from './hello.component';
@@ -40,8 +40,8 @@ test('hello', async ({ mount }) => {
     expect(result.content).toContain(`\
 import { test } from '@testronaut/angular';
 import { Hello } from './hello.component';
-test('hello', async ({ runInBrowser }) => {
-    await runInBrowser('hello', () => mount(Hello));
+test('hello', async ({ inPage }) => {
+    await inPage('hello', () => mount(Hello));
 });
 `);
   });
@@ -68,8 +68,8 @@ test('hello', async ({ mount }) => {
     const result = transform(`
 import { test } from '@testronaut/angular';
 
-test('hello', async ({ runInBrowser }) => {
-  await runInBrowser(() => {
+test('hello', async ({ inPage }) => {
+  await inPage(() => {
     console.log('hello');
   });
 });

--- a/packages/angular/src/lib/playwright/angular-transform.ts
+++ b/packages/angular/src/lib/playwright/angular-transform.ts
@@ -1,7 +1,7 @@
 import {
   AnalysisContext,
   createImportedIdentifier,
-  getRunInBrowserIdentifier,
+  getInPageIdentifier,
   type Transform,
   type TransformResult,
 } from '@testronaut/core/devkit';
@@ -26,7 +26,7 @@ export const angularTransform: Transform = {
         replacePropertyInObjectBinding(
           node,
           MOUNT_IDENTIFIER,
-          getRunInBrowserIdentifier()
+          getInPageIdentifier()
         ),
       callExpression: (node) => {
         if (node.expression.getText() !== MOUNT_IDENTIFIER) {
@@ -35,12 +35,12 @@ export const angularTransform: Transform = {
 
         mountFound = true;
 
-        const { mountArgs, runInBrowserArgs } = processMountArgs(
+        const { mountArgs, inPageArgs } = processMountArgs(
           Array.from(node.arguments)
         );
 
-        return createCallExpression(getRunInBrowserIdentifier(), [
-          ...runInBrowserArgs,
+        return createCallExpression(getInPageIdentifier(), [
+          ...inPageArgs,
           createArrowFunction(
             createCallExpression(MOUNT_IDENTIFIER, mountArgs)
           ),
@@ -63,13 +63,13 @@ export const angularTransform: Transform = {
 };
 
 function processMountArgs(args: ts.Expression[]): {
-  runInBrowserArgs: ts.Expression[];
+  inPageArgs: ts.Expression[];
   mountArgs: ts.Expression[];
 } {
   const isNamedCall = ts.isStringLiteral(args[0]);
 
   return {
-    runInBrowserArgs: isNamedCall ? [args[0]] : [],
+    inPageArgs: isNamedCall ? [args[0]] : [],
     mountArgs: isNamedCall ? args.slice(1) : args,
   };
 }

--- a/packages/angular/src/lib/playwright/fixtures.ts
+++ b/packages/angular/src/lib/playwright/fixtures.ts
@@ -11,7 +11,7 @@ import {
 export { expect } from '@testronaut/core';
 
 export const test = base.extend<Fixtures>({
-  mount: async ({ page, runInBrowser }, use) => {
+  mount: async ({ page, inPage }, use) => {
     const mountImpl: Fixtures['mount'] = async <CMP_TYPE extends Type<unknown>>(
       ...args: MountParameters<CMP_TYPE>
     ) => {
@@ -22,16 +22,16 @@ export const test = base.extend<Fixtures>({
 
       const inputs = options?.inputs;
 
-      /* Using a placeholder function here because what matters to `runInBrowser`
+      /* Using a placeholder function here because what matters to `inPage`
        * is the name (if not anonymous). */
       const { outputNames } =
         functionName != null
-          ? await runInBrowser(
+          ? await inPage(
               functionName,
               { inputs },
               placeholderMount<CMP_TYPE>
             )
-          : await runInBrowser({ inputs }, placeholderMount<CMP_TYPE>);
+          : await inPage({ inputs }, placeholderMount<CMP_TYPE>);
 
       const { outputsCalls } = await listenToOutputBus({ page, outputNames });
 

--- a/packages/core/src/devkit.ts
+++ b/packages/core/src/devkit.ts
@@ -1,4 +1,4 @@
-export { getRunInBrowserIdentifier } from './lib/core/run-in-browser-identifier';
+export { getInPageIdentifier } from './lib/core/run-in-browser-identifier';
 export {
   AnalysisContext,
   createFileData,

--- a/packages/core/src/lib/analyzer/analyze.spec.ts
+++ b/packages/core/src/lib/analyzer/analyze.spec.ts
@@ -1,22 +1,22 @@
 import { describe } from 'vitest';
 import { FileAnalysis } from '../core/file-analysis';
 import { analyze } from './analyze';
-import { InvalidRunInBrowserCallError } from './visit-run-in-browser-calls';
+import { InvalidInPageCallError } from './visit-run-in-browser-calls';
 
 describe(analyze.name, () => {
   it('generates file hash', () => {
     const { hash } = analyzeFileContent(`
-test('...', async ({runInBrowser}) => {
-  await runInBrowser(() => console.log('Hello!'));
+test('...', async ({inPage}) => {
+  await inPage(() => console.log('Hello!'));
 });
     `);
-    expect(hash).toBe('dzvDWHTi');
+    expect(hash).toBe('MLZi2ARp');
   });
 
-  it('extracts `runInBrowser` sync arrow function', () => {
+  it('extracts `inPage` sync arrow function', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test('...', async ({runInBrowser}) => {
-  await runInBrowser(() => console.log('Hello!'));
+test('...', async ({inPage}) => {
+  await inPage(() => console.log('Hello!'));
 });
     `);
     expect(extractedFunctions).toEqual([
@@ -27,10 +27,10 @@ test('...', async ({runInBrowser}) => {
     ]);
   });
 
-  it('extracts `runInBrowser` async arrow function', () => {
+  it('extracts `inPage` async arrow function', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test('...', async ({runInBrowser}) => {
-  await runInBrowser(async () => console.log('Hello!'));
+test('...', async ({inPage}) => {
+  await inPage(async () => console.log('Hello!'));
 });
     `);
     expect(extractedFunctions).toEqual([
@@ -41,10 +41,10 @@ test('...', async ({runInBrowser}) => {
     ]);
   });
 
-  it('extracts `runInBrowser` function call', () => {
+  it('extracts `inPage` function call', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test('...', async ({runInBrowser}) => {
-  await runInBrowser(function sayHello() { console.log('Hello!'); });
+test('...', async ({inPage}) => {
+  await inPage(function sayHello() { console.log('Hello!'); });
 });
     `);
     expect(extractedFunctions).toEqual([
@@ -55,10 +55,10 @@ test('...', async ({runInBrowser}) => {
     ]);
   });
 
-  it('extracts `runInBrowser` outside test: in beforeEach', () => {
+  it('extracts `inPage` outside test: in beforeEach', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test.beforeEach(async ({runInBrowser}) => {
-  await runInBrowser(() => console.log('Hello!'));
+test.beforeEach(async ({inPage}) => {
+  await inPage(() => console.log('Hello!'));
 });
     `);
     expect(extractedFunctions).toEqual([
@@ -69,10 +69,10 @@ test.beforeEach(async ({runInBrowser}) => {
     ]);
   });
 
-  it('extracts `runInBrowser` outside test: in a function', () => {
+  it('extracts `inPage` outside test: in a function', () => {
     const { extractedFunctions } = analyzeFileContent(`
 function somewhereElse() {
-  await runInBrowser(() => console.log('Hello!'));
+  await inPage(() => console.log('Hello!'));
 }
     `);
     expect(extractedFunctions).toEqual([
@@ -83,10 +83,10 @@ function somewhereElse() {
     ]);
   });
 
-  it('extracts named `runInBrowser`', () => {
+  it('extracts named `inPage`', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test('...', async ({runInBrowser}) => {
-  await runInBrowser('say hello', () => console.log('Hello!'));
+test('...', async ({inPage}) => {
+  await inPage('say hello', () => console.log('Hello!'));
 });
     `);
     expect(extractedFunctions).toEqual([
@@ -98,9 +98,9 @@ test('...', async ({runInBrowser}) => {
     ]);
   });
 
-  it('extracts aliased `runInBrowser`', () => {
+  it('extracts aliased `inPage`', () => {
     const { extractedFunctions } = analyzeFileContent(`
-test('...', async ({runInBrowser: run}) => {
+test('...', async ({inPage: run}) => {
   await run(() => console.log('Hello!'));
 });
     `);
@@ -112,18 +112,18 @@ test('...', async ({runInBrowser: run}) => {
     ]);
   });
 
-  it('extracts imported identifiers used in `runInBrowser`', () => {
+  it('extracts imported identifiers used in `inPage`', () => {
     const { extractedFunctions } = analyzeFileContent(`
 import { something, somethingElse, somethingUsedOutside } from './something';
 import { somethingFromAnotherFile } from './another-file';
 
 console.log(somethingUsedOutside);
 
-runInBrowser('say hi', () => {
+inPage('say hi', () => {
   console.log(something);
 });
 
-runInBrowser('say bye', () => {
+inPage('say bye', () => {
   console.log(something);
   console.log(somethingFromAnotherFile);
 });
@@ -154,46 +154,46 @@ runInBrowser('say bye', () => {
     ]);
   });
 
-  it.todo('extracts imported identifiers with alias used in `runInBrowser`');
+  it.todo('extracts imported identifiers with alias used in `inPage`');
 
   it.todo(
-    'extracts imported identifiers with default import used in `runInBrowser`'
+    'extracts imported identifiers with default import used in `inPage`'
   );
 
   it.todo(
-    'extracts imported identifiers with namespace used in `runInBrowser`'
+    'extracts imported identifiers with namespace used in `inPage`'
   );
 
-  it('fails if `runInBrowser` is called without args', () => {
-    expect(() => analyzeFileContent(`runInBrowser();`)).toThrow(
-      InvalidRunInBrowserCallError
+  it('fails if `inPage` is called without args', () => {
+    expect(() => analyzeFileContent(`inPage();`)).toThrow(
+      InvalidInPageCallError
     );
   });
 
-  it('fails if `runInBrowser` is called with too many args', () => {
+  it('fails if `inPage` is called with too many args', () => {
     expect(() =>
       analyzeFileContent(
-        `runInBrowser('say hi', () => console.log('Say hi!'), 'superfluous');`
+        `inPage('say hi', () => console.log('Say hi!'), 'superfluous');`
       )
-    ).toThrow(InvalidRunInBrowserCallError);
+    ).toThrow(InvalidInPageCallError);
   });
 
-  it('fails if `runInBrowser` name is not a string literal', () => {
+  it('fails if `inPage` name is not a string literal', () => {
     expect(() =>
       analyzeFileContent(`
 const name = 'say hi';
-runInBrowser(name, () => console.log('Say hi!'));
+inPage(name, () => console.log('Say hi!'));
       `)
-    ).toThrow(InvalidRunInBrowserCallError);
+    ).toThrow(InvalidInPageCallError);
   });
 
-  it('fails if `runInBrowser` function is not an inline function', () => {
+  it('fails if `inPage` function is not an inline function', () => {
     expect(() =>
       analyzeFileContent(`
 const fn = () => console.log('Say hi!');
-runInBrowser(fn);
+inPage(fn);
       `)
-    ).toThrow(InvalidRunInBrowserCallError);
+    ).toThrow(InvalidInPageCallError);
   });
 });
 

--- a/packages/core/src/lib/analyzer/analyze.ts
+++ b/packages/core/src/lib/analyzer/analyze.ts
@@ -9,7 +9,7 @@ import {
 import { AnalysisContext, createFileData, type FileData } from './core';
 import type { Transform } from './transform';
 import { visitImportedIdentifiers } from './visit-imported-identifiers';
-import { visitRunInBrowserCalls } from './visit-run-in-browser-calls';
+import { visitInPageCalls } from './visit-run-in-browser-calls';
 
 export function analyze({
   fileData,
@@ -39,18 +39,18 @@ export function analyze({
 
   const extractedFunctions: ExtractedFunction[] = [];
 
-  /* Extract `runInBrowser` calls. */
-  visitRunInBrowserCalls(ctx, (runInBrowserCall) => {
-    /* Extracted identifiers inside `runInBrowser` call that are imported. */
+  /* Extract `inPage` calls. */
+  visitInPageCalls(ctx, (inPageCall) => {
+    /* Extracted identifiers inside `inPage` call that are imported. */
     const importedIdentifiers: ImportedIdentifier[] = [];
-    visitImportedIdentifiers(ctx, runInBrowserCall.node, (importedIdentifier) =>
+    visitImportedIdentifiers(ctx, inPageCall.node, (importedIdentifier) =>
       importedIdentifiers.push(importedIdentifier)
     );
 
     extractedFunctions.push(
       createExtractedFunction({
-        code: runInBrowserCall.code,
-        name: runInBrowserCall.name,
+        code: inPageCall.code,
+        name: inPageCall.name,
         importedIdentifiers,
       })
     );

--- a/packages/core/src/lib/analyzer/visit-imported-identifiers.ts
+++ b/packages/core/src/lib/analyzer/visit-imported-identifiers.ts
@@ -8,7 +8,7 @@ import { findImportDeclaration, getDeclaration } from './utils';
 
 export function visitImportedIdentifiers(
   ctx: AnalysisContext,
-  runInBrowserCallNode: ts.CallExpression,
+  inPageCallNode: ts.CallExpression,
   callback: (importedIdentifier: ImportedIdentifier) => void
 ) {
   const visitor = (node: ts.Node) => {
@@ -23,7 +23,7 @@ export function visitImportedIdentifiers(
     ts.forEachChild(node, visitor);
   };
 
-  ts.forEachChild(runInBrowserCallNode, visitor);
+  ts.forEachChild(inPageCallNode, visitor);
 }
 
 function tryGetImportedIdentifier(

--- a/packages/core/src/lib/core/run-in-browser-identifier.ts
+++ b/packages/core/src/lib/core/run-in-browser-identifier.ts
@@ -3,6 +3,6 @@
  * this is public API, a function is probably more future-proof in case
  * we have to dynamically decide which identifier to use for compatibility.
  */
-export function getRunInBrowserIdentifier(): string {
-  return 'runInBrowser';
+export function getInPageIdentifier(): string {
+  return 'inPage';
 }

--- a/packages/core/src/lib/extraction-writer/extraction-writer.spec.ts
+++ b/packages/core/src/lib/extraction-writer/extraction-writer.spec.ts
@@ -50,7 +50,7 @@ describe(ExtractionWriter.name, () => {
     ).toContain('INITIAL_CONTENT');
   });
 
-  it('writes anonymous `runInBrowser` calls', async () => {
+  it('writes anonymous `inPage` calls', async () => {
     const { fileSystemFake, projectFileAnalysisMother, writer } =
       await setUpInitializedWriter();
 
@@ -103,7 +103,7 @@ export const extractedFunctionsRecord = {
     });
   });
 
-  it('writes named `runInBrowser` calls', async () => {
+  it('writes named `inPage` calls', async () => {
     const { fileSystemFake, projectFileAnalysisMother, writer } =
       await setUpInitializedWriter();
 

--- a/packages/core/src/lib/playwright/fixtures.ts
+++ b/packages/core/src/lib/playwright/fixtures.ts
@@ -55,7 +55,7 @@ export const test: TestronautTestType = base.extend<
     await use(page);
   },
 
-  runInBrowser: async ({ testronaut, page }, use, testInfo) => {
+  inPage: async ({ testronaut, page }, use, testInfo) => {
     if (!testronaut) {
       /* TODO: Setup a link with detailed instructions */
       throw new Error(
@@ -73,7 +73,7 @@ export const test: TestronautTestType = base.extend<
     );
     const { hash } = await runner.extract(testInfo.file);
 
-    const runInBrowserImpl: RunInBrowser = async (...args: unknown[]) => {
+    const inPageImpl: InPage = async (...args: unknown[]) => {
       let functionName = '';
       if (typeof args[0] === 'string') {
         functionName = args[0];
@@ -85,22 +85,22 @@ export const test: TestronautTestType = base.extend<
         data = args[0] as Record<string, unknown>;
       }
 
-      return await runner.runInBrowser({
+      return await runner.inPage({
         hash,
         functionName,
         data,
       });
     };
 
-    await use(runInBrowserImpl);
+    await use(inPageImpl);
   },
 });
 
 export interface Fixtures {
-  runInBrowser: RunInBrowser;
+  inPage: InPage;
 }
 
-export interface RunInBrowser {
+export interface InPage {
   <RETURN>(fn: () => RETURN | Promise<RETURN>): Promise<RETURN>;
 
   <RETURN>(name: string, fn: () => RETURN | Promise<RETURN>): Promise<RETURN>;

--- a/packages/core/src/lib/playwright/options.ts
+++ b/packages/core/src/lib/playwright/options.ts
@@ -27,7 +27,7 @@ export interface TestronautOptions {
   /**
    * List of transforms to apply to files before extraction.
    * This is used by framework plugins to transform fixtures
-   * such as `mount()` to `runInBrowser()`.
+   * such as `mount()` to `inPage()`.
    */
   transforms?: Transform[];
 }

--- a/packages/core/src/lib/runner/extraction-pipeline.ts
+++ b/packages/core/src/lib/runner/extraction-pipeline.ts
@@ -32,7 +32,7 @@ export class ExtractionPipeline {
 
     /* TODO: it's cheap to just throw an error here.
      * Later, we'll have to extract the errors so that we can throw them
-     * when `runInBrowser` is called in the test.*/
+     * when `inPage` is called in the test.*/
     assertNoDuplicateExtractedFunctions(fileAnalysis);
 
     const fileInfo = createFileInfo({ hash: this.#computeHash(content), path });

--- a/packages/core/src/lib/runner/runner.ts
+++ b/packages/core/src/lib/runner/runner.ts
@@ -14,7 +14,7 @@ export class Runner {
     return this.#extractionPipeline.extract(filePath);
   }
 
-  async runInBrowser({
+  async inPage({
     hash,
     functionName,
     data,

--- a/tests/angular-wide/src/app/config.failing-multi-worker-pw.ts
+++ b/tests/angular-wide/src/app/config.failing-multi-worker-pw.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@testronaut/core';
  * We run two tests, skip the first one, and make sure the second one crashes. */
 for (let i = 0; i < 2; i++) {
   test(`fail if there is more than one worker ${i}`, async ({
-    runInBrowser,
+    inPage,
   }, testInfo) => {
     /* It seems that Playwright will always run the first test in the first worker.
      * If this behavior changes, we will have to adapt this condition and make
@@ -13,10 +13,10 @@ for (let i = 0; i < 2; i++) {
     console.log(testInfo.parallelIndex);
 
     await expect(async () => {
-      await runInBrowser(() => {
+      await inPage(() => {
         document.body.textContent =
           'This test fails before because there are two workers!';
       });
-    }).rejects.toThrow('`runInBrowser` does not support multiple workers yet.');
+    }).rejects.toThrow('`inPage` does not support multiple workers yet.');
   });
 }

--- a/tests/angular-wide/src/app/greetings.pw.ts
+++ b/tests/angular-wide/src/app/greetings.pw.ts
@@ -18,8 +18,8 @@ test(`named mount with inputs`, async ({ page, mount }) => {
   await expect(page.getByRole('heading')).toHaveText('Hello Foo!');
 });
 
-test(`named mount with DI`, async ({ page, mount, runInBrowser }) => {
-  await runInBrowser('configure providers', () =>
+test(`named mount with DI`, async ({ page, mount, inPage }) => {
+  await inPage('configure providers', () =>
     configure({ providers: [provideGreeting('Servus')] })
   );
 

--- a/tests/angular-wide/src/app/run-in-browser-no-duplicate-names.pw.ts
+++ b/tests/angular-wide/src/app/run-in-browser-no-duplicate-names.pw.ts
@@ -1,17 +1,17 @@
 import { test } from '@testronaut/core';
 
-/* TODO: once we make `runInBrowser` throw instead,
- * we can `expect(() => runInBrowser(...)).rejects.toThrow()` instead. */
-test.fail('runInBrowser', async ({ runInBrowser }) => {
-  await runInBrowser('duplicate name', () => {
+/* TODO: once we make `inPage` throw instead,
+ * we can `expect(() => inPage(...)).rejects.toThrow()` instead. */
+test.fail('inPage', async ({ inPage }) => {
+  await inPage('duplicate name', () => {
     document.body.textContent = 'Hi!';
   });
 });
 
 test.fail(
-  'another runInBrowser with the same name',
-  async ({ runInBrowser }) => {
-    await runInBrowser('duplicate name', () => {
+  'another inPage with the same name',
+  async ({ inPage }) => {
+    await inPage('duplicate name', () => {
       document.body.textContent = 'Bye!';
     });
   }

--- a/tests/angular-wide/src/app/run-in-browser-one-anonymous.pw.ts
+++ b/tests/angular-wide/src/app/run-in-browser-one-anonymous.pw.ts
@@ -1,15 +1,15 @@
 import { test } from '@testronaut/core';
 
-/* TODO: once we make `runInBrowser` throw instead,
- * we can `expect(() => runInBrowser(...)).rejects.toThrow()` instead. */
-test.fail('anonymous runInBrowser', async ({ runInBrowser }) => {
-  await runInBrowser(() => {
+/* TODO: once we make `inPage` throw instead,
+ * we can `expect(() => inPage(...)).rejects.toThrow()` instead. */
+test.fail('anonymous inPage', async ({ inPage }) => {
+  await inPage(() => {
     document.body.textContent = 'Hi!';
   });
 });
 
-test.fail('another anonymous runInBrowser', async ({ runInBrowser }) => {
-  await runInBrowser(() => {
+test.fail('another anonymous inPage', async ({ inPage }) => {
+  await inPage(() => {
     document.body.textContent = 'Bye!';
   });
 });

--- a/tests/angular-wide/src/app/run-in-browser.pw.ts
+++ b/tests/angular-wide/src/app/run-in-browser.pw.ts
@@ -1,23 +1,23 @@
 import { expect, test } from '@testronaut/core';
 
-test('anonymous runInBrowser', async ({ page, runInBrowser }) => {
-  await runInBrowser(() => {
+test('anonymous inPage', async ({ page, inPage }) => {
+  await inPage(() => {
     document.body.textContent = 'Hi!';
   });
 
   await expect(page.getByText('Hi!')).toBeVisible();
 });
 
-test('named runInBrowser', async ({ page, runInBrowser }) => {
-  await runInBrowser('hello', () => {
+test('named inPage', async ({ page, inPage }) => {
+  await inPage('hello', () => {
     document.body.textContent = 'Hello!';
   });
 
   await expect(page.getByText('Hello!')).toBeVisible();
 });
 
-test('named runInBrowser with args', async ({ page, runInBrowser }) => {
-  await runInBrowser('hello foo', { name: 'Foo' }, ({ name }) => {
+test('named inPage with args', async ({ page, inPage }) => {
+  await inPage('hello foo', { name: 'Foo' }, ({ name }) => {
     document.body.textContent = `Hello ${name}!`;
   });
 


### PR DESCRIPTION
This is the first PR. It renames to `inPage` throughout the whole codebase. Some filenames kept `runInBrowser`. That was done to keep the git history.

The second PR will rename those files (so that history stays intact).

Implements #104

Changes:
- Renamed core identifier from `runInBrowser` to `inPage`
- Updated all fixture types and interfaces
- Renamed analyzer files and functions
- Updated all test and demo files
- Renamed test files to match new naming convention