### PR TITLE
build: auto update playwright max supported version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@playwright/test"],
+      "postUpgradeTasks": {
+        "commands": [
+          "node scripts/set-playwright-max-version.mts {{{newVersion}}}",
+          "pnpm install --update-lockfile"
+        ],
+        "fileFilters": [
+          "packages/angular/src/schematics/init/playwright-version.json",
+          "packages/core/package.json",
+          "packages/angular/package.json",
+          "pnpm-lock.yaml"
+        ],
+        "installTools": {
+          "pnpm": {}
+        }
+      }
+    }
+  ]
+}

--- a/scripts/set-playwright-max-version.mts
+++ b/scripts/set-playwright-max-version.mts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { valid } from 'semver';
+
+const __filename = import.meta.filename;
+const __dirname = path.dirname(__filename);
+
+main();
+
+/**
+ * Sets playwright-version.json `upper` and @playwright/test peer ranges in @testronaut/core and @testronaut/angular.
+ */
+function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const playwrightVersionJsonPath = path.join(
+    rootDir,
+    'packages/angular/src/schematics/init/playwright-version.json'
+  );
+  const libPackagePaths = {
+    core: path.join(rootDir, 'packages/core/package.json'),
+    angular: path.join(rootDir, 'packages/angular/package.json'),
+  } as const;
+
+  const rawArg = process.argv[2];
+  if (rawArg === undefined || rawArg === '') {
+    console.error('Usage: set-playwright-max-version.mts <version>');
+    process.exit(1);
+  }
+
+  const normalized = (rawArg.startsWith('v') ? rawArg.slice(1) : rawArg).trim();
+  const coerced = valid(normalized);
+  if (coerced === null) {
+    console.error(`Invalid semver version: ${JSON.stringify(rawArg)}`);
+    process.exit(1);
+  }
+
+  const upper = coerced;
+  const versionDoc = readJson(playwrightVersionJsonPath) as {
+    lower: string;
+    upper: string;
+  };
+  const { lower } = versionDoc;
+  versionDoc.upper = upper;
+  writeJson(playwrightVersionJsonPath, versionDoc);
+
+  const peerRange = `>=${lower} <=${upper}`;
+  for (const [name, pkgPath] of Object.entries(libPackagePaths)) {
+    const pkg = readJson(pkgPath) as {
+      peerDependencies?: Record<string, string>;
+    };
+    if (!pkg.peerDependencies?.['@playwright/test']) {
+      console.error(
+        `Could not find @playwright/test peer dependency in packages/${name}/package.json.`
+      );
+      process.exit(1);
+    }
+    pkg.peerDependencies['@playwright/test'] = peerRange;
+    writeJson(pkgPath, pkg);
+  }
+
+  console.log(`Set Playwright max to ${upper} (peer range: ${peerRange}).`);
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath: string, data: unknown) {
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}


### PR DESCRIPTION
Let Renovate update Playwright's max version.

## TODO
- [ ] test renovate config by forking repo and merge this into the main branch
- [ ] merge `check-playwright-version-sync.mjs` and `set-playwright-max-version.mts` into a single command: `playwright-max-version [check|set]`