### PR TITLE
feat(core): add captureInPageCallLocation utility

### DIFF
--- a/packages/core/src/lib/playwright/capture-in-page-call-location.spec.ts
+++ b/packages/core/src/lib/playwright/capture-in-page-call-location.spec.ts
@@ -1,0 +1,25 @@
+import { _parseCallerFrame } from './capture-in-page-call-location';
+
+describe(_parseCallerFrame.name, () => {
+  it('parses a Unix stack frame', () => {
+    expect(
+      _parseCallerFrame('    at file:///home/user/test.ts:10:5')
+    ).toStrictEqual({ filePath: '/home/user/test.ts', line: 10 });
+  });
+
+  it('parses a Windows stack frame', () => {
+    expect(
+      _parseCallerFrame('    at file:///C:/Users/user/test.ts:10:5')
+    ).toStrictEqual({ filePath: 'C:\\Users\\user\\test.ts', line: 10 });
+  });
+
+  it('returns null for a Node internal frame', () => {
+    expect(
+      _parseCallerFrame('    at node:internal/process:123:5')
+    ).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(_parseCallerFrame(undefined)).toBeNull();
+  });
+});

--- a/packages/core/src/lib/playwright/capture-in-page-call-location.ts
+++ b/packages/core/src/lib/playwright/capture-in-page-call-location.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url';
+
+export function captureInPageCallLocation(): { filePath: string; line: number } | null {
+  const frames = (new Error().stack ?? '').split('\n');
+  // Stack: [0] "Error", [1] captureInPageCallLocation, [2] inPageImpl, [3] caller
+  return _parseCallerFrame(frames[3]);
+}
+
+export function _parseCallerFrame(
+  frame: string | undefined
+): { filePath: string; line: number } | null {
+  if (!frame) return null;
+  const match = frame.match(/^ +at (file:\/\/\/.+):(\d+):\d+$/);
+  if (!match) return null;
+  return {
+    filePath: fileURLToPath(match[1]),
+    line: parseInt(match[2], 10),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `captureInPageCallLocation()` — inspects the call stack at runtime to return the file path and line number of the `inPage` call site
- Adds `_parseCallerFrame()` — parses a `file:///...` V8 stack frame into `{ filePath, line }`, handles both Unix and Windows paths via `fileURLToPath`, returns `null` for Node internals or missing frames
- No existing files modified — purely additive

## Context

Part of the effort to replace lax-hash identification with source line numbers for anonymous `inPage` calls (see #139). This is the foundational piece: a self-contained utility with its own unit tests that subsequent PRs will wire up into the analyzer and fixtures.

## Test plan

- [ ] `captureInPageCallLocation` unit tests pass: Unix path, Windows path, Node internal frame, undefined input
- [ ] No regressions in existing core tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to capture caller file path and line number information from error stacks, with support for both Unix and Windows file paths.

* **Tests**
  * Added unit tests to verify proper parsing of stack frame information and handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->