### PR TITLE
fix: disable SSR in testronaut build configuration

### DIFF
--- a/demos/angular/project.json
+++ b/demos/angular/project.json
@@ -49,6 +49,9 @@
         "testronaut": {
           "optimization": false,
           "extractLicenses": false,
+          "outputMode": "static",
+          "server": false,
+          "ssr": false,
           "sourceMap": true,
           "browser": "demos/angular/testronaut/main.ts",
           "index": "demos/angular/testronaut/index.html",

--- a/nx.json
+++ b/nx.json
@@ -55,6 +55,7 @@
     },
     "@nx/eslint:lint": {
       "cache": true,
+      "dependsOn": ["^build"],
       "inputs": [
         "default",
         "{workspaceRoot}/.eslintrc.json",

--- a/packages/angular/src/schematics/init/index.spec.ts
+++ b/packages/angular/src/schematics/init/index.spec.ts
@@ -54,6 +54,9 @@ describe('ng-add generator', () => {
         ).toMatchObject({
           optimization: false,
           extractLicenses: false,
+          outputMode: 'static',
+          server: false,
+          ssr: false,
           sourceMap: true,
           browser: `${folder}testronaut/main.ts`,
           index: `${folder}testronaut/index.html`,
@@ -163,6 +166,9 @@ describe('ng-add generator', () => {
       expect(targets?.['build']?.configurations?.['testronaut']).toMatchObject({
         optimization: false,
         extractLicenses: false,
+        outputMode: 'static',
+        server: false,
+        ssr: false,
         sourceMap: true,
         browser: `${folder}testronaut/main.ts`,
         index: `${folder}testronaut/index.html`,

--- a/packages/angular/src/schematics/init/index.ts
+++ b/packages/angular/src/schematics/init/index.ts
@@ -76,6 +76,9 @@ export async function initGenerator(
       sourceMap: true,
       optimization: false,
       extractLicenses: false,
+      outputMode: 'static',
+      server: false,
+      ssr: false,
     };
     testronautConfig[`${'main' in testronautConfig ? 'main' : 'browser'}`] = `${
       root ? `${root}/` : ''


### PR DESCRIPTION
## Summary

- Adds `outputMode: 'static'`, `server: false`, and `ssr: false` to the testronaut build configuration generated by the `ng add` schematic.

## Bug

When a project has SSR enabled in its `angular.json`, the testronaut build configuration inherits those SSR settings. This causes `ng serve` to fail when running with the `testronaut` configuration, because the testronaut setup is not built for server-side rendering. The fix explicitly disables SSR so the testronaut config is always treated as a static client-only build, regardless of what the parent project has configured.

## Test plan

- [ ] Run `ng add @testronaut/angular` on a project with SSR enabled and verify `ng serve --configuration testronaut` starts without error
- [ ] Existing unit tests (`packages/angular/src/schematics/init/index.spec.ts`) updated to assert the new fields are present